### PR TITLE
Travis CIの設定変更

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,7 @@ bundler_args: "--without development --deployment"
 cache: bundler
 before_script:
 - cp config/database.travis.yml config/database.yml
-- bundle exec rake db:create
-- bundle exec rake db:migrate
+- bundle exec rake db:setup
 script:
 - bundle exec rake test
 notifications:


### PR DESCRIPTION
## 概要

`db:create`, `db:migrat`eを`db:setup`に変更する
## 参考

[マイグレーション](http://www.techscore.com/tech/Ruby/Rails/model/migration/3)
