### PR TITLE
Sprocketsのdeprecationに対応する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ ruby '2.3.1'
 
 gem 'rails',                   '5.0.0.1'
 gem 'puma',                    '3.4.0'
-gem 'sass-rails',              '5.0.5'
+gem 'sass-rails',              '5.0.6'
 gem 'uglifier',                '3.0.0'
 gem 'coffee-rails',            '4.2.1'
 gem 'jquery-rails',            '4.1.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -220,7 +220,7 @@ GEM
       json (~> 1.4)
     ruby-progressbar (1.8.1)
     sass (3.4.22)
-    sass-rails (5.0.5)
+    sass-rails (5.0.6)
       railties (>= 4.0.0, < 6)
       sass (~> 3.1)
       sprockets (>= 2.8, < 4.0)
@@ -301,7 +301,7 @@ DEPENDENCIES
   rails_12factor (= 0.0.2)
   rb-readline
   rbnacl-libsodium
-  sass-rails (= 5.0.5)
+  sass-rails (= 5.0.6)
   sdoc (= 0.4.0)
   spring (= 1.7.1)
   spring-watcher-listen (= 2.0.0)


### PR DESCRIPTION
## 概要

サーバにデプロイした直後に以下のwarningが発生したので修正する
### Warning

```
01 DEPRECATION WARNING: Sprockets method `register_engine` is deprecated.
01 Please register a mime type using `register_mime_type` then
01 use `register_compressor` or `register_transformer`.
01 https://github.com/rails/sprockets/blob/master/guides/extending_sprockets.md#supporting-all-versions-of-sprockets-in-processors
```
### 詳細

https://teratail.com/questions/43607
